### PR TITLE
Dashes and underscores in id and class attributes

### DIFF
--- a/HandsomeSoup.cabal
+++ b/HandsomeSoup.cabal
@@ -7,7 +7,7 @@ Name:                HandsomeSoup
 -- The package version. See the Haskell package versioning policy
 -- (http://www.haskell.org/haskellwiki/Package_versioning_policy) for
 -- standards guiding when and how versions should be incremented.
-Version:             0.3.1
+Version:             0.3.2
 
 -- A short (one-line) description of the package.
 Synopsis:            Work with HTML more easily in HXT


### PR DESCRIPTION
Hi, thanks for the package!

I've found what it refuses to parse many real world tags because your lexer is too strict. Take a look at http://www.w3.org/TR/CSS21/grammar.html

I made a quick fix for supporting dashes and underscores in id and class attributes. 
