### PR TITLE
Drop MaybeT package dependency

### DIFF
--- a/HandsomeSoup.cabal
+++ b/HandsomeSoup.cabal
@@ -26,12 +26,11 @@ library
                     , Text.CSS.Parser
   Other-modules:      Text.CSS.Utils
   Build-depends:      base            >= 4.6  &&  < 5
-                    , transformers
+                    , transformers    >= 0.3
                     , HTTP
                     , parsec
                     , containers
                     , mtl
-                    , MaybeT
                     , hxt
                     , hxt-http
   if flag(network-uri)

--- a/src/Text/HandsomeSoup.hs
+++ b/src/Text/HandsomeSoup.hs
@@ -4,7 +4,7 @@ import Text.XML.HXT.Core
 import Network.HTTP
 import Network.URI
 import Data.Tree.NTree.TypeDefs
-import Control.Monad.Maybe
+import Control.Monad.Trans.Maybe
 import Control.Monad.Trans
 import Data.Maybe
 import Text.Parsec


### PR DESCRIPTION
That package has been superceded by transformers itself. MaybeT does not
support GHC 7.10, which in turn blocks HandsomeSoup from working with
7.10.