### PR TITLE
Allow arbitrary characters in attribute selectors.

### DIFF
--- a/HandsomeSoup.cabal
+++ b/HandsomeSoup.cabal
@@ -1,5 +1,5 @@
 Name:               HandsomeSoup
-Version:            0.4
+Version:            0.4.1
 Synopsis:           Work with HTML more easily in HXT
 Description:        See examples and full readme on the Github page: https:\/\/github.com\/egonSchiele\/HandsomeSoup
 Homepage:           https://github.com/egonSchiele/HandsomeSoup
@@ -66,4 +66,3 @@ executable handsomesoup
   Build-depends:   base            >= 4.6  &&  < 5
                  , HandsomeSoup
                  , hxt
-

--- a/src/Text/CSS/Parser.hs
+++ b/src/Text/CSS/Parser.hs
@@ -13,7 +13,7 @@ import Text.CSS.Utils
 -- if the attr value is prefixed with a '~', we treat
 -- that attribute as a list of words separated by a space
 -- and make sure that at least one of those words matches.
--- 
+--
 -- if the attr value is prefixed with a `|`, the value must
 -- be exactly val or start with val immediately followed by a '-'.
 -- This is primarily intended to allow language subcode matches.
@@ -69,12 +69,12 @@ idSelector = do
 -- | selects attributes, like @ [id] @ (element must have id) or @ [id=foo] @ (element must have id foo).
 attributeSelector :: ParsecT [Char] u I.Identity ([Char], [Char])
 attributeSelector = do
-      _contents <- between (char '[') (char ']') (many1 (alphaNum <|> oneOf "/-_|~=\"'."))
+      _contents <- between (char '[') (char ']') (many1 (noneOf "[]"))
       -- remove quotes
       let contents = filter (\c -> c /= '"' && c /= '\'') _contents
-      if "~=" `isInfixOf` contents 
+      if "~=" `isInfixOf` contents
           then return $ (\(a, b) -> (a, '~':b)) $ splitOn "~=" contents
-          else if "|=" `isInfixOf` contents 
+          else if "|=" `isInfixOf` contents
               then return $ (\(a, b) -> (a, '|':b)) $ splitOn "|=" contents
               else if '=' `elem` contents
                    then return $ splitOn "=" contents
@@ -120,7 +120,7 @@ simpleSelectorNoTag = do
 simpleSelector :: ParsecT [Char] u I.Identity Selector
 simpleSelector = simpleSelectorTag <|> simpleSelectorNoTag <|> try childOf <|> try followedBy <|> space_
 
--- | One or more simple selectors separated by combinators. 
+-- | One or more simple selectors separated by combinators.
 selector :: ParsecT [Char] u I.Identity [[Selector]]
 selector = many1 simpleSelector `sepBy` (spaces >> string "," >> spaces)
 


### PR DESCRIPTION
I'm parsing some links with `?` and `&` characters in them, but currently HandsomeSoup only allows numbers, letters and some special characters (`/-_|~="'.`) inside attribute selectors.

From browsing the [CSS2 spec and grammar][css2-grammar], it seems "anything goes" when it comes to the content of an attribute selector, so I've updated the parser to allow all characters except `[` and `]`.

My editor also trimmed some trailing whitespace, which I'm happy to put back if you like :stuck_out_tongue:.

This change fixes my application but if you can foresee any negatives, let me know!

[css2-grammar]: http://www.w3.org/TR/CSS21/grammar.html